### PR TITLE
Replace WhatsApp with Signal and add Wildwuchs event

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -70,6 +70,10 @@
             background-color: #333333;
             color: white;
         }
+        .btn-signal {
+            background-color: #3a76f0;
+            color: white;
+        }
     </style>
 </head>
 
@@ -161,15 +165,15 @@
                                 </a>
                             </div>
                             <div class="col-6 col-sm-3 col-md-3">
-                                <a href="https://chat.whatsapp.com/EsglrmsdkHL5IEsUMlgc6C"
-                                   class="btn btn-success" role="button"
+                                <a href="https://signal.group/#CjQKIMaRIiMrwLoGLWte8td5Miy7SM6Bjjwywugat1Ve924DEhBXB0DS80vmJ9jP1OCscnUM"
+                                   class="btn btn-signal" role="button"
                                    target="_blank"
                                 >
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
-                                         class="bi bi-whatsapp" viewBox="0 0 16 16">
-                                        <path d="M13.601 2.326A7.85 7.85 0 0 0 7.994 0C3.627 0 .068 3.558.064 7.926c0 1.399.366 2.76 1.057 3.965L0 16l4.204-1.102a7.9 7.9 0 0 0 3.79.965h.004c4.368 0 7.926-3.558 7.93-7.93A7.9 7.9 0 0 0 13.6 2.326zM7.994 14.521a6.6 6.6 0 0 1-3.356-.92l-.24-.144-2.494.654.666-2.433-.156-.251a6.56 6.56 0 0 1-1.007-3.505c0-3.626 2.957-6.584 6.591-6.584a6.56 6.56 0 0 1 4.66 1.931 6.56 6.56 0 0 1 1.928 4.66c-.004 3.639-2.961 6.592-6.592 6.592m3.615-4.934c-.197-.099-1.17-.578-1.353-.646-.182-.065-.315-.099-.445.099-.133.197-.513.646-.627.775-.114.133-.232.148-.43.05-.197-.1-.836-.308-1.592-.985-.59-.525-.985-1.175-1.103-1.372-.114-.198-.011-.304.088-.403.087-.088.197-.232.296-.346.1-.114.133-.198.198-.33.065-.134.034-.248-.015-.347-.05-.099-.445-1.076-.612-1.47-.16-.389-.323-.335-.445-.34-.114-.007-.247-.007-.38-.007a.73.73 0 0 0-.529.247c-.182.198-.691.677-.691 1.654s.71 1.916.81 2.049c.098.133 1.394 2.132 3.383 2.992.47.205.84.326 1.129.418.475.152.904.129 1.246.08.38-.058 1.171-.48 1.338-.943.164-.464.164-.86.114-.943-.049-.084-.182-.133-.38-.232"/>
+                                         class="bi bi-signal" viewBox="0 0 16 16">
+                                        <path d="M8 1.5A6.5 6.5 0 0 0 2.2 11l-.8 3.1 3.2-.8A6.5 6.5 0 1 0 8 1.5Zm0 1.2a5.3 5.3 0 1 1-2.8 9.8l-.2-.1-1.8.5.5-1.8-.1-.2A5.3 5.3 0 0 1 8 2.7Zm-2.8 3.9h5.6v1H5.2v-1Zm0 2h4.2v1H5.2v-1Z"/>
                                     </svg>
-                                    <span>Whatsapp</span>
+                                    <span>Signal</span>
                                 </a>
                             </div>
                         </div>
@@ -199,11 +203,16 @@
                         </thead>
                         <tbody>
                         <tr class="upcoming-event">
+                            <td>27.06.26 18:00-23:59 Uhr</td>
+                            <td>Wildwuchs Brauereifest</td>
+                            <td>Jaffestraße 8, 21109 Hamburg</td>
+                        </tr>
+                        <tr class="past-event">
                             <td>05/06.06.26</td>
                             <td>Hamburg Beer Festival 2026</td>
                             <td>Altes Mädchen, Schanzenhöfe, Hamburg</td>
                         </tr>
-                        <tr class="upcoming-event">
+                        <tr class="past-event">
                             <td>30.05.26</td>
                             <td>Beer Battle: Hamburg vs. Berlin</td>
                             <td>Bunker Hamburg</td>


### PR DESCRIPTION
Replaces the WhatsApp social button with Signal, adds the Wildwuchs Brauereifest as the next highlighted event, and marks BeerBattle and Hamburg Beer Festival as past events.